### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,19 +4,19 @@ Links:
  * home: https://github.com/ponty/confduino
  * documentation: http://ponty.github.com/confduino
  
-.. image:: https://pypip.in/version/confduino/badge.svg
+.. image:: https://img.shields.io/pypi/v/confduino.svg
     :target: https://pypi.python.org/pypi/confduino/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/confduino/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/confduino.svg
     :target: https://pypi.python.org/pypi/confduino/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/license/confduino/badge.svg
+.. image:: https://img.shields.io/pypi/l/confduino.svg
     :target: https://pypi.python.org/pypi/confduino/
     :alt: License
             
-.. image:: https://pypip.in/download/confduino/badge.svg
+.. image:: https://img.shields.io/pypi/dm/confduino.svg
     :target: https://pypi.python.org/pypi/confduino/
     :alt: Downloads
     


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20confduino))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `confduino`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.